### PR TITLE
fix: use stdenv.{host,build}Platform instead of deprecated aliases

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -86,7 +86,7 @@ rec {
 
     let
       inherit (pkgs) binutils lib stdenv;
-      inherit (crossPkgs) buildPlatform hostPlatform;
+      inherit (crossPkgs.stdenv) buildPlatform hostPlatform;
       inherit (lib) getExe' importTOML optional;
       inherit (hostPlatform) isWindows;
 
@@ -226,7 +226,7 @@ rec {
           };
         in
         {
-          "cross-${crossPkgs.hostPlatform.system}" = withGitEnvs crossPkg;
+          "cross-${crossPkgs.stdenv.hostPlatform.system}" = withGitEnvs crossPkg;
         };
 
     in


### PR DESCRIPTION
`mkDefault` reads `crossPkgs.hostPlatform` / `crossPkgs.buildPlatform`,
and `mkCrossPackage` builds an attr name from `crossPkgs.hostPlatform.system`.
nixpkgs converted those to warning-emitting aliases on 2025-10-28
(`pkgs/top-level/aliases.nix`):

    evaluation warning: 'hostPlatform' has been renamed to/replaced by
      'stdenv.hostPlatform'

Because `mkCrossPackages` iterates every cross target, downstream flakes
(himalaya, neverest, etc.) emit roughly a dozen of these warnings per
`system.build.toplevel` eval on `x86_64-linux`.

This PR just inserts `.stdenv` in two places. No behavior change.