### PR TITLE
fix(ci): rewrite Nix store dylib paths for macOS binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,23 @@ jobs:
       - run: nix build .#cross-${{ inputs.target }} --no-write-lock-file
       - run: cp result/bin/${{ inputs.project }}* .
       - run: chmod u+w ${{ inputs.project }}*
+      - if: ${{ endsWith(inputs.target, '-darwin') }}
+        run: |
+          # Rewrite Nix store library paths to system paths so the
+          # binary can run on vanilla macOS without Nix installed.
+          # See: https://github.com/pimalaya/himalaya/issues/694
+          for f in ${{ inputs.project }}*; do
+            otool -L "$f" | grep -o '/nix/store/[^ ]*' | while read -r nix_path; do
+              lib="$(basename "$nix_path")"
+              target="/usr/lib/$lib"
+              if [ -f "$target" ]; then
+                echo "  $nix_path → $target"
+                install_name_tool -change "$nix_path" "$target" "$f"
+              else
+                echo "  WARNING: no system equivalent for $nix_path ($lib not in /usr/lib/)"
+              fi
+            done
+          done
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.project }}-${{ inputs.target }}


### PR DESCRIPTION
## Problem

macOS binaries built by the Nix release workflow cannot run on vanilla macOS.
The binary crashes immediately:

```
dyld[43178]: Library not loaded: /nix/store/nc9k1wrfq4rnsfysgvjn9xsvdlikm4rf-libiconv-109.100.2/lib/libiconv.2.dylib
  Referenced from: /path/to/himalaya
  Reason: tried: '/nix/store/...' (no such file)
```

This affects all Darwin targets (aarch64-darwin, x86_64-darwin) built via the
`pimalaya/nix` shared workflow, because `nix build .#cross-*-darwin` produces
binaries with hardcoded `/nix/store/...` dylib paths. On systems without Nix
installed, those paths don't exist.

Reported upstream: pimalaya/himalaya#694

## Root cause analysis

The release workflow (`.github/workflows/release.yml`) does:

```
nix build .#cross-aarch64-darwin
cp result/bin/himalaya .
```

The Nix build output binary links libraries via their absolute Nix store paths.
For macOS, this includes `libiconv.2.dylib` at a `/nix/store/...` path. On any
Mac without Nix installed, `dyld` cannot resolve these paths and the binary
fails to launch.

This was observed in the wild on macOS 15 (Sequoia) with the latest CI build
from commit `0a073e6` of pimalaya/himalaya.

The same binary compiled via `cargo build --release` on macOS links against
`/usr/lib/libiconv.2.dylib` (the system library) and works correctly — proving
the issue is in the Nix build output, not the Rust code.

The root cause is that the nixpkgs pin in downstream projects (e.g. himalaya)
was changed from `staging-next` to a fixed `nixos-25.11` revision. Different
nixpkgs versions package libiconv differently: `staging-next` happened to
produce a binary that linked against the system libiconv, while `nixos-25.11`
links against the Nix store copy. But the fix should be on the CI side, not
on the nixpkgs choice — the release workflow should produce portable binaries
regardless of which nixpkgs version is used.

## Fix

Add a post-build step for Darwin targets that rewrites Nix store library paths
to the corresponding system paths under `/usr/lib` using `install_name_tool`
(a standard macOS tool from Xcode CLT, pre-installed on GitHub Actions runners):

```yaml
- if: ${{ endsWith(inputs.target, '-darwin') }}
  run: |
    for f in ${{ inputs.project }}*; do
      otool -L "$f" | grep -o '/nix/store/[^ ]*' | while read -r nix_path; do
        lib="$(basename "$nix_path")"
        target="/usr/lib/$lib"
        if [ -f "$target" ]; then
          echo "  $nix_path → $target"
          install_name_tool -change "$nix_path" "$target" "$f"
        else
          echo "  WARNING: no system equivalent for $nix_path ($lib not in /usr/lib/)"
        fi
      done
    done
```

Design decisions:
- **Only runs on Darwin targets** — no impact on Linux/Windows builds
- **Iterates over all Nix store paths** — not just libiconv, for future-proofing
- **Checks target exists before rewriting** — prints WARNING instead of failing if a Nix library has no `/usr/lib/` equivalent
- **Uses `/usr/lib/`** — Apple system library path, identical on Intel and Apple Silicon

## Testing

Manually verified on macOS 15 (ARM64):
- Before: binary from CI artifact crashes with "Library not loaded: /nix/store/..."
- After `install_name_tool -change`: binary runs and `--version` succeeds

`otool -L` confirms all dependencies resolve to system paths after the fix.